### PR TITLE
Reinstate branch graph core classes.

### DIFF
--- a/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
+++ b/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
@@ -160,7 +160,6 @@ public abstract class BranchGraphImp<
 
 		graph.releaseRef( vertexRef );
 		graphRebuilt();
-		graph.addGraphListener( this );
 	}
 
 	@Override

--- a/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
+++ b/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
@@ -303,6 +303,17 @@ public abstract class BranchGraphImp<
 		return beeMap.get( be, ref );
 	}
 
+	@Override
+	protected void clear()
+	{
+		vbvMap.clear();
+		vbeMap.clear();
+		ebeMap.clear();
+		bvvMap.clear();
+		beeMap.clear();
+		super.clear();
+	}
+
 	/*
 	 * Graph listener
 	 */

--- a/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
+++ b/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
@@ -79,8 +79,9 @@ public abstract class BranchGraphImp<
 	BV extends AbstractListenableVertex< BV, BE, BVP, T >, 
 	BE extends AbstractListenableEdge< BE, BV, BEP, T >, 
 	BVP extends AbstractListenableVertexPool< BV, BE, T >, 
-	BEP extends AbstractListenableEdgePool< BE, BV, T >, T extends MappedElement >
-		extends	ListenableGraphImp< BVP, BEP, BV, BE, T >
+	BEP extends AbstractListenableEdgePool< BE, BV, T >, 
+	T extends MappedElement >
+		extends ListenableGraphImp< BVP, BEP, BV, BE, T >
 		implements GraphListener< V, E >, BranchGraph< BV, BE, V, E >
 {
 
@@ -144,6 +145,7 @@ public abstract class BranchGraphImp<
 		this.beeMap = RefMaps.createRefRefMap( edges(), graph.edges() );
 		final V vertexRef = graph.vertexRef();
 		this.assigner = Assigner.getFor( vertexRef );
+
 		graph.releaseRef( vertexRef );
 		graphRebuilt();
 		graph.addGraphListener( this );
@@ -308,6 +310,8 @@ public abstract class BranchGraphImp<
 			final BE refBE1 = edgeRef();
 			final BE refBE2 = edgeRef();
 			final BE refBE3 = edgeRef();
+			final BE refBE4 = edgeRef();
+			final BE refBE5 = edgeRef();
 			final BV refBV1 = vertexRef();
 			final BV refBV2 = vertexRef();
 			final V refLV1 = graph.vertexRef();
@@ -351,10 +355,19 @@ public abstract class BranchGraphImp<
 				final V lv2 = bvvMap.get( bvTarget, refLV2 );
 
 				// Remove bv, beIn, beOut from branch graph.
-				super.remove( bv );
+				/*
+				 * We will remove bv from the graph. So we also need to be
+				 * cautious and unmap the links TO its edges, as well as the
+				 * mapping FROM it.
+				 */
+				final E e1 = beeMap.removeWithRef( beIn, refLE3 );
+				final E e2 = beeMap.removeWithRef( beOut, refLE4 );
+				ebeMap.removeWithRef( e1, refBE4 );
+				ebeMap.removeWithRef( e2, refBE5 );
 				bvvMap.removeWithRef( bv, refLV3 );
 				beeMap.removeWithRef( beIn, refLE3 );
 				beeMap.removeWithRef( beOut, refLE4 );
+				super.remove( bv );
 
 				// beNew := new branch edge between bvSource and bvTarget.
 				final BE beNew = init( super.addEdge( bvSource, bvTarget, refBE3 ), le );
@@ -379,6 +392,8 @@ public abstract class BranchGraphImp<
 			releaseRef( refBE1 );
 			releaseRef( refBE2 );
 			releaseRef( refBE3 );
+			releaseRef( refBE4 );
+			releaseRef( refBE5 );
 		}
 	}
 

--- a/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
+++ b/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
@@ -372,10 +372,8 @@ public abstract class BranchGraphImp<
 				 * cautious and unmap the links TO its edges, as well as the
 				 * mapping FROM it.
 				 */
-				final E e1 = beeMap.removeWithRef( beIn, refLE3 );
-				final E e2 = beeMap.removeWithRef( beOut, refLE4 );
-				ebeMap.removeWithRef( e1, refBE4 );
-				ebeMap.removeWithRef( e2, refBE5 );
+				beeMap.removeWithRef( beIn, refLE3 );
+				beeMap.removeWithRef( beOut, refLE4 );
 				bvvMap.removeWithRef( bv, refLV3 );
 				beeMap.removeWithRef( beIn, refLE3 );
 				beeMap.removeWithRef( beOut, refLE4 );
@@ -387,8 +385,7 @@ public abstract class BranchGraphImp<
 				// reference f3 from every source graph vertex on the path
 				linkBranchEdge( lv1, lv2, beNew );
 
-				// link from f3 to source edge that was previously linked from
-				// f1
+				// link from f3 to source edge that was previously linked from f1
 				beeMap.put( beNew, le, refLE2 );
 			}
 
@@ -907,6 +904,31 @@ public abstract class BranchGraphImp<
 		for ( final BE be : edges() )
 			sb.append( "    " + str( be, eref ) + "\n" );
 		sb.append( "  }\n" );
+
+		sb.append( "  mapping v->bv = {\n" );
+		for ( final V v : vbvMap.keySet() )
+			sb.append( "    " + v + " -> " + vbvMap.get( v ) + "\n" );
+		sb.append( "  },\n" );
+
+		sb.append( "  mapping bv->v = {\n" );
+		for ( final BV bv : bvvMap.keySet() )
+			sb.append( "    " + bv + " -> " + bvvMap.get( bv ) + "\n" );
+		sb.append( "  },\n" );
+
+		sb.append( "  mapping v->be = {\n" );
+		for ( final V v : vbeMap.keySet() )
+			sb.append( "    " + v + " -> " + vbeMap.get( v ) + "\n" );
+		sb.append( "  },\n" );
+
+		sb.append( "  mapping e->be = {\n" );
+		for ( final E e : ebeMap.keySet() )
+			sb.append( "    " + e + " -> " + ebeMap.get( e ) + "\n" );
+		sb.append( "  },\n" );
+		sb.append( "  mapping be->e = {\n" );
+		for ( final BE be : beeMap.keySet() )
+			sb.append( "    " + be + " -> " + beeMap.get( be ) + "\n" );
+		sb.append( "  },\n" );
+
 		sb.append( "}" );
 
 		graph.releaseRef( vref );

--- a/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
+++ b/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
@@ -686,7 +686,7 @@ public abstract class BranchGraphImp<
 					{
 						// Merge point, we have to create a branch.
 						// Does a BV already exists for this vertex?
-						BV bvEnd = vbvMap.get( v, bvRef1 );
+						BV bvEnd = vbvMap.get( v, bvRef3 );
 						if ( bvEnd == null )
 						{
 							// Create node.

--- a/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
+++ b/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
@@ -31,9 +31,12 @@ package org.mastodon.graph.branch;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.mastodon.collection.RefCollections;
 import org.mastodon.collection.RefList;
 import org.mastodon.collection.RefMaps;
 import org.mastodon.collection.RefRefMap;
+import org.mastodon.collection.RefSet;
+import org.mastodon.collection.RefStack;
 import org.mastodon.graph.Edge;
 import org.mastodon.graph.Edges;
 import org.mastodon.graph.GraphIdBimap;
@@ -41,7 +44,9 @@ import org.mastodon.graph.GraphListener;
 import org.mastodon.graph.ListenableGraph;
 import org.mastodon.graph.Vertex;
 import org.mastodon.graph.algorithm.Assigner;
+import org.mastodon.graph.algorithm.RootFinder;
 import org.mastodon.graph.algorithm.ShortestPath;
+import org.mastodon.graph.algorithm.traversal.DepthFirstIterator;
 import org.mastodon.graph.algorithm.traversal.GraphSearch.SearchDirection;
 import org.mastodon.graph.ref.AbstractListenableEdge;
 import org.mastodon.graph.ref.AbstractListenableEdgePool;
@@ -635,11 +640,90 @@ public abstract class BranchGraphImp<
 	{
 		clear();
 
-		for ( final V v : graph.vertices() )
-			vertexAdded( v );
+		final BV bvRef1 = vertexRef(); // -> bv of a root.
+		final BV bvRef2 = vertexRef(); // -> previous mapping of root.
+		final BV bvRef3 = vertexRef(); // -> to create a new bv.
+		final BE beRef1 = edgeRef(); // -> new be of a branch.
+		final BE beRef2 = edgeRef(); // -> previous mapping of first edge.
+		final V vRef1 = graph.vertexRef(); // -> root of a branch.
+		final V vRef2 = graph.vertexRef(); // -> previous mapping of bv root.
+		final V vRef3 = graph.vertexRef(); // -> second vertex of a branch.
+		final E eRef = graph.edgeRef(); // -> previous mapping of be.
 
-		for ( final E e : graph.edges() )
-			edgeAdded( e );
+		final DepthFirstIterator< V, E > it = new DepthFirstIterator<>( graph );
+
+		// Keep track of what we should iterate from.
+		final RefSet< V > roots = RootFinder.getRoots( graph );
+		final RefStack< V > queue = RefCollections.createRefStack( graph.vertices() );
+		queue.addAll( roots );
+
+		// To avoid iterating several times the same branch when we have graphs
+		// with merge events.
+		final RefSet< V > visited = RefCollections.createRefSet( graph.vertices() );
+
+		while ( !queue.isEmpty() )
+		{
+			final V root = queue.pop( vRef1 );
+
+			// Create or get first node.
+			BV bvBegin = vbvMap.get( root, bvRef1 );
+			if ( bvBegin == null )
+			{
+				bvBegin = init( super.addVertex( bvRef1 ), root );
+				vbvMap.put( root, bvBegin, bvRef2 );
+				bvvMap.put( bvBegin, root, vRef2 );
+			}
+
+			// Successors of the node.
+			for ( final E firstEdge : root.outgoingEdges() )
+			{
+				final V firstTarget = firstEdge.getTarget( vRef3 );
+				if ( visited.contains( firstTarget ) )
+					continue;
+				visited.add( firstTarget );
+
+				it.reset( firstTarget );
+				while ( it.hasNext() )
+				{
+					final V v = it.next();
+					if ( v.incomingEdges().size() != 1 || v.outgoingEdges().size() != 1 )
+					{
+						// Merge point, we have to create a branch.
+						// Does a BV already exists for this vertex?
+						BV bvEnd = vbvMap.get( v, bvRef1 );
+						if ( bvEnd == null )
+						{
+							// Create node.
+							bvEnd = init( super.addVertex( bvRef3 ), v );
+							vbvMap.put( v, bvEnd, bvRef2 );
+							bvvMap.put( bvEnd, v, vRef2 );
+						}
+
+						// Edge that connect to previous node.
+						final BE be = init( super.addEdge( bvBegin, bvEnd, beRef1 ), firstEdge );
+						ebeMap.put( firstEdge, be, beRef2 );
+						beeMap.put( be, firstEdge, eRef );
+
+						// Walk back the branch to map it properly.
+						linkBranchEdge( firstTarget, v, be );
+
+						// Reset iteration.
+						queue.add( v );
+						break;
+					}
+				}
+			}
+		}
+
+		releaseRef( bvRef1 );
+		releaseRef( bvRef2 );
+		releaseRef( bvRef3 );
+		releaseRef( beRef1 );
+		releaseRef( beRef2 );
+		graph.releaseRef( vRef1 );
+		graph.releaseRef( vRef2 );
+		graph.releaseRef( vRef3 );
+		graph.releaseRef( eRef );
 
 		notifyGraphChanged();
 	}

--- a/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
+++ b/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
@@ -73,15 +73,14 @@ import org.mastodon.pool.MappedElement;
  *            the type of {@link MappedElement} used for the vertex and edge
  *            pool.
  */
-public abstract class BranchGraphImp<
-	V extends Vertex< E >,
-	E extends Edge< V >,
-	BV extends AbstractListenableVertex< BV, BE, BVP, T >,
-	BE extends AbstractListenableEdge< BE, BV, BEP, T >,
-	BVP extends AbstractListenableVertexPool< BV, BE, T >,
-	BEP extends AbstractListenableEdgePool< BE, BV, T >,
-	T extends MappedElement >
-		extends ListenableGraphImp<	BVP, BEP, BV, BE, T >
+public abstract class BranchGraphImp< 
+	V extends Vertex< E >, 
+	E extends Edge< V >, 
+	BV extends AbstractListenableVertex< BV, BE, BVP, T >, 
+	BE extends AbstractListenableEdge< BE, BV, BEP, T >, 
+	BVP extends AbstractListenableVertexPool< BV, BE, T >, 
+	BEP extends AbstractListenableEdgePool< BE, BV, T >, T extends MappedElement >
+		extends	ListenableGraphImp< BVP, BEP, BV, BE, T >
 		implements GraphListener< V, E >, BranchGraph< BV, BE, V, E >
 {
 
@@ -605,6 +604,8 @@ public abstract class BranchGraphImp<
 
 		for ( final E e : graph.edges() )
 			edgeAdded( e );
+
+		notifyGraphChanged();
 	}
 
 	@Override
@@ -621,6 +622,8 @@ public abstract class BranchGraphImp<
 		releaseRef( bvRef1 );
 		releaseRef( bvRef2 );
 		graph.releaseRef( vRef );
+
+		notifyGraphChanged();
 	}
 
 	@Override
@@ -642,6 +645,8 @@ public abstract class BranchGraphImp<
 		releaseRef( bvRef2 );
 		releaseRef( beRef );
 		graph.releaseRef( vRef );
+
+		notifyGraphChanged();
 	}
 
 	@Override
@@ -743,6 +748,8 @@ public abstract class BranchGraphImp<
 		graph.releaseRef( ref2 );
 		releaseRef( vref1 );
 		releaseRef( vref2 );
+
+		notifyGraphChanged();
 	}
 
 	@Override
@@ -751,11 +758,12 @@ public abstract class BranchGraphImp<
 		// Possibly add branch vertices to make up for removed link.
 		releaseBranchEdgeFor( edge );
 
-		
 		// Remove edge from map.
 		final BE beRef = edgeRef();
 		ebeMap.removeWithRef( edge, beRef );
 		releaseRef( beRef );
+
+		notifyGraphChanged();
 	}
 
 	/*

--- a/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
+++ b/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java
@@ -69,7 +69,7 @@ import org.mastodon.pool.MappedElement;
  * connected component in the core-graph looks like this:
  * 
  * <pre>
- * A -> B -> C -> D -> A
+ * A -&gt; B -&gt; C -&gt; D -&gt; A
  * </pre>
  * 
  * (edge direction is important), it won't be discovered in the branch-graph,
@@ -77,13 +77,13 @@ import org.mastodon.pool.MappedElement;
  * edges. 'Diamonds' connected components:
  * 
  * <pre>
- * A -> B -> D
+ * A -&gt; B -&gt; D
  * </pre>
  * 
  * and
  * 
  * <pre>
- * A -> C -> D
+ * A -&gt; C -&gt; D
  * </pre>
  * 
  * are supported.

--- a/src/test/java/org/mastodon/graph/branch/BranchGraphGraphRebuiltTest.java
+++ b/src/test/java/org/mastodon/graph/branch/BranchGraphGraphRebuiltTest.java
@@ -1,0 +1,1029 @@
+/*-
+ * #%L
+ * Mastodon Graphs
+ * %%
+ * Copyright (C) 2015 - 2021 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.graph.branch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mastodon.collection.RefCollection;
+import org.mastodon.collection.RefCollections;
+import org.mastodon.collection.RefList;
+import org.mastodon.graph.GraphListener;
+import org.mastodon.graph.ListenableTestEdge;
+import org.mastodon.graph.ListenableTestGraph;
+import org.mastodon.graph.ListenableTestVertex;
+
+/**
+ * Variation of the {@link BranchGraphTest} where we do not listen to
+ * incremental changes, but rely on calling the
+ * {@link GraphListener#graphRebuilt()} method.
+ * 
+ * @author Jean-Yves Tinevez
+ *
+ */
+public class BranchGraphGraphRebuiltTest
+{
+
+	private ListenableTestGraph graph;
+
+	private BranchTestGraph bg;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		this.graph = new ListenableTestGraph();
+		this.bg = new BranchTestGraph( graph, new BranchTestEdgePool( 50, new BranchTestVertexPool( 50 ) ) );
+		// Do NOT listen to incremental changes.
+		graph.removeGraphListener( bg );
+	}
+
+	@Test
+	public void testAddOneVertex()
+	{
+		final ListenableTestVertex v0 = graph.addVertex().init( 0, 0 );
+		bg.graphRebuilt();
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int size = vertices.size();
+		assertEquals( "Expected the branch graph to have 1 vertex.", 1, size );
+
+		final BranchTestVertex bv = vertices.iterator().next();
+		assertEquals( "Branch vertex does not link to expected linked vertex.",
+				v0, bg.getLinkedVertex( bv, graph.vertexRef() ) );
+
+		final BranchTestVertex bv0 = bg.getBranchVertex( v0, bg.vertexRef() );
+		assertEquals( "Linked vertex does not link to expected branch vertex.",
+				bv, bv0 );
+	}
+
+	@Test
+	public void testAddTwoVertices()
+	{
+		final ListenableTestVertex v0 = graph.addVertex().init( 0, 0 );
+		final ListenableTestVertex v1 = graph.addVertex().init( 1, 1 );
+		bg.graphRebuilt();
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int size = vertices.size();
+		assertEquals( "Expected the branch graph to have 2 vertices.", 2, size );
+
+		final BranchTestVertex bv0 = bg.getBranchVertex( v0, bg.vertexRef() );
+		assertEquals( "Branch vertex does not link to expected linked vertex.",
+				v0, bg.getLinkedVertex( bv0, graph.vertexRef() ) );
+
+		final BranchTestVertex bv1 = bg.getBranchVertex( v1, bg.vertexRef() );
+		assertEquals( "Branch vertex does not link to expected linked vertex.",
+				v1, bg.getLinkedVertex( bv1, graph.vertexRef() ) );
+	}
+
+	@Test
+	public void testLinkTwoVertices()
+	{
+		final ListenableTestVertex v0 = graph.addVertex().init( 0, 0 );
+		final ListenableTestVertex v1 = graph.addVertex().init( 1, 1 );
+		final ListenableTestEdge e0 = graph.addEdge( v0, v1 ).init();
+		bg.graphRebuilt();
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 2 vertices.", 2, vSize );
+
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 1 edge.", 1, eSize );
+
+		final BranchTestVertex bv0 = bg.getBranchVertex( v0, bg.vertexRef() );
+		assertEquals( "Branch vertex does not link to expected linked vertex.",
+				v0, bg.getLinkedVertex( bv0, graph.vertexRef() ) );
+
+		final BranchTestVertex bv1 = bg.getBranchVertex( v1, bg.vertexRef() );
+		assertEquals( "Branch vertex does not link to expected linked vertex.",
+				v1, bg.getLinkedVertex( bv1, graph.vertexRef() ) );
+
+		final BranchTestEdge be0 = bg.getBranchEdge( e0, bg.edgeRef() );
+		assertEquals( "Branch edge does not link to expected linked vertex.",
+				e0, bg.getLinkedEdge( be0, graph.edgeRef() ) );
+	}
+
+	@Test
+	public void testLinkSeveralVertices()
+	{
+		// This order first: 2 vertices - 1 edge - 1 vertex - 1 edge.
+		final ListenableTestVertex v0 = graph.addVertex().init( 0, 0 );
+		final ListenableTestVertex v1 = graph.addVertex().init( 1, 1 );
+		final ListenableTestEdge e0 = graph.addEdge( v0, v1 ).init();
+		final ListenableTestVertex v2 = graph.addVertex().init( 2, 1 );
+		final ListenableTestEdge e1 = graph.addEdge( v1, v2 ).init();
+		bg.graphRebuilt();
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 2 vertices.", 2, vSize );
+
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 1 edge.", 1, eSize );
+
+		final BranchTestVertex bv0 = bg.getBranchVertex( v0, bg.vertexRef() );
+		assertEquals( "Branch vertex does not link to expected linked vertex.",
+				v0, bg.getLinkedVertex( bv0, graph.vertexRef() ) );
+
+		final BranchTestVertex bv1 = bg.getBranchVertex( v1, bg.vertexRef() );
+		assertNull( "Branch vertex linked to a non-joint vertex should be null.", bv1 );
+
+		final BranchTestVertex bv2 = bg.getBranchVertex( v2, bg.vertexRef() );
+		assertEquals( "Branch vertex does not link to expected linked vertex.",
+				v2, bg.getLinkedVertex( bv2, graph.vertexRef() ) );
+
+		final BranchTestEdge be0 = bg.getBranchEdge( e0, bg.edgeRef() );
+		assertEquals( "Branch edge does not link to expected linked vertex.",
+				e0, bg.getLinkedEdge( be0, graph.edgeRef() ) );
+
+		final BranchTestEdge be1 = bg.getBranchEdge( e1, bg.edgeRef() );
+		assertEquals( "Non-join edge should link to the same branch edge.", be0, be1 );
+	}
+
+	@Test
+	public void testLinkManyVertices()
+	{
+		// First all vertices then all edges.
+		final RefList< ListenableTestVertex > vlist = RefCollections.createRefList( graph.vertices() );
+		for ( int i = 0; i < 5; i++ )
+			vlist.add( graph.addVertex().init( i, i ) );
+		final RefList< ListenableTestEdge > elist = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex ref1 = graph.vertexRef();
+		final ListenableTestVertex ref2 = graph.vertexRef();
+		final ListenableTestEdge eref = graph.edgeRef();
+		for ( int i = 0; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex source = vlist.get( i, ref1 );
+			final ListenableTestVertex target = vlist.get( i + 1, ref2 );
+			final ListenableTestEdge edge = graph.addEdge( source, target, eref ).init();
+			elist.add( edge );
+		}
+		bg.graphRebuilt();
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 2 vertices.", 2, vSize );
+
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 1 edge.", 1, eSize );
+
+		final ListenableTestVertex v0 = vlist.get( 0 );
+		final BranchTestVertex bv0 = bg.getBranchVertex( v0, bg.vertexRef() );
+		assertNotNull( "First linked vertex should link to a branch vertex.", bv0 );
+		assertEquals( "First branch vertex should link to first linked vertex in the branch.",
+				v0, bg.getLinkedVertex( bv0, graph.vertexRef() ) );
+
+		final ListenableTestVertex vlast = vlist.get( vlist.size() - 1 );
+		final BranchTestVertex bvlast = bg.getBranchVertex( vlast, bg.vertexRef() );
+		assertNotNull( "Last linked vertex should link to a branch vertex.", bvlast );
+		assertEquals( "Last branch vertex should link to last linked vertex in the branch.",
+				vlast, bg.getLinkedVertex( bvlast, graph.vertexRef() ) );
+
+		final BranchTestEdge be = bg.edges().iterator().next();
+		final ListenableTestEdge e0 = elist.get( 0 );
+		assertEquals( "Branch edge should link to first linked edge in the branch.",
+				e0, bg.getLinkedEdge( be, graph.edgeRef() ) );
+
+
+		final BranchTestEdge beref = bg.edgeRef();
+		for ( int i = 1; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex vi = vlist.get( i, ref1 );
+			assertNull( "Middle vertex should not link to a branch vertex.", bg.getBranchVertex( vi, bg.vertexRef() ) );
+			final BranchTestEdge bei = bg.getBranchEdge( vi, beref );
+			assertNotNull( "Middle vertex should link to a branch edge.", bei );
+			assertEquals( "Middle vertex shoud link to the branch edge.", be, bei );
+		}
+
+		for ( final ListenableTestEdge ei : elist )
+			assertEquals( "Linked edge should link to the branch edge.", be, bg.getBranchEdge( ei, beref ) );
+
+		graph.releaseRef( ref1 );
+		graph.releaseRef( ref2 );
+		graph.releaseRef( eref );
+		bg.releaseRef( beref );
+	}
+
+	@Test
+	public void testRemoveOneEdge()
+	{
+		final RefList< ListenableTestVertex > vlist = RefCollections.createRefList( graph.vertices() );
+		for ( int i = 0; i < 6; i++ )
+			vlist.add( graph.addVertex().init( i, i ) );
+		final RefList< ListenableTestEdge > elist = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex ref1 = graph.vertexRef();
+		final ListenableTestVertex ref2 = graph.vertexRef();
+		final ListenableTestEdge eref = graph.edgeRef();
+		for ( int i = 0; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex source = vlist.get( i, ref1 );
+			final ListenableTestVertex target = vlist.get( i + 1, ref2 );
+			final ListenableTestEdge edge = graph.addEdge( source, target, eref ).init();
+			elist.add( edge );
+		}
+
+		// Remove middle edge.
+		final ListenableTestEdge removedEdge = elist.get( elist.size() / 2 );
+		final ListenableTestVertex oldSource = removedEdge.getSource();
+		final ListenableTestVertex oldTarget = removedEdge.getTarget();
+		graph.remove( removedEdge );
+		bg.graphRebuilt();
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 4 vertices.", 4, vSize );
+
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 2 edges.", 2, eSize );
+
+		// Does stuff link to new branch vertex?
+		final BranchTestVertex newBVsource = bg.getBranchVertex( oldSource, bg.vertexRef() );
+		assertNotNull( "Old source linked vertex should link to a branch vertex.", newBVsource );
+		assertEquals( "New branch vertex should link to old source linked vertex.", oldSource, bg.getLinkedVertex( newBVsource, ref1 ) );
+
+		final BranchTestVertex newBVtarget = bg.getBranchVertex( oldTarget, bg.vertexRef() );
+		assertNotNull( "Old target linked vertex should link to a branch vertex.", newBVtarget );
+		assertEquals( "New branch vertex should link to old target linked vertex.", oldTarget, bg.getLinkedVertex( newBVtarget, ref2 ) );
+
+		// Does stuff link to branch edge?
+		final BranchTestEdge newIncomingBE = newBVsource.incomingEdges().get( 0 );
+		assertEquals( "New incoming branch edge should link to first linked edge in the branch.",
+				elist.get( 0 ), bg.getLinkedEdge( newIncomingBE, graph.edgeRef() ) );
+		for ( int i = 0; i < elist.size() / 2; i++ )
+			assertEquals( "Linked edge in the new first branch should link to new incoming branch edge.",
+					newIncomingBE, bg.getBranchEdge( elist.get( i ), bg.edgeRef() ) );
+		for ( int i = 1; i < vlist.size() / 2 - 1; i++ )
+			assertEquals( "Middle vertex in the new first branch should link to new incoming branch edge.",
+					newIncomingBE, bg.getBranchEdge( vlist.get( i ), bg.edgeRef() ) );
+
+		final BranchTestEdge newOutgoingBE = newBVtarget.outgoingEdges().get( 0 );
+		assertEquals( "New outgoing branch edge should link to first linked edge in the second branch.",
+				elist.get( elist.size() / 2 + 1 ), bg.getLinkedEdge( newOutgoingBE, graph.edgeRef() ) );
+		for ( int i = elist.size() / 2 + 1; i < elist.size(); i++ )
+			assertEquals( "Linked edge in the new second branch should link to new ougoing branch edge.",
+					newOutgoingBE, bg.getBranchEdge( elist.get( i ), bg.edgeRef() ) );
+		for ( int i = vlist.size() / 2 + 1; i < vlist.size() - 1; i++ )
+			assertEquals( "Middle vertex in the new second branch should link to new outgoing branch edge.",
+					newOutgoingBE, bg.getBranchEdge( vlist.get( i ), bg.edgeRef() ) );
+
+		graph.releaseRef( ref1 );
+		graph.releaseRef( ref2 );
+		graph.releaseRef( eref );
+	}
+
+	@Test
+	public void testRemoveStartVertex()
+	{
+		final RefList< ListenableTestVertex > vlist = RefCollections.createRefList( graph.vertices() );
+		for ( int i = 0; i < 6; i++ )
+			vlist.add( graph.addVertex().init( i, i ) );
+		final RefList< ListenableTestEdge > elist = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex ref1 = graph.vertexRef();
+		final ListenableTestVertex ref2 = graph.vertexRef();
+		final ListenableTestEdge eref = graph.edgeRef();
+		for ( int i = 0; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex source = vlist.get( i, ref1 );
+			final ListenableTestVertex target = vlist.get( i + 1, ref2 );
+			final ListenableTestEdge edge = graph.addEdge( source, target, eref ).init();
+			elist.add( edge );
+		}
+
+		// Remove first vertex.
+		graph.remove( vlist.get( 0 ) );
+		bg.graphRebuilt();
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 2 vertices.", 2, vSize );
+
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 1 edge.", 1, eSize );
+
+		final ListenableTestVertex v1 = vlist.get( 1 );
+		final BranchTestVertex bv0 = bg.getBranchVertex( v1, bg.vertexRef() );
+		assertNotNull( "First linked vertex should link to a branch vertex.", bv0 );
+		assertEquals( "First branch vertex should link to first linked vertex in the branch.",
+				v1, bg.getLinkedVertex( bv0, graph.vertexRef() ) );
+
+		final ListenableTestVertex vlast = vlist.get( vlist.size() - 1 );
+		final BranchTestVertex bvlast = bg.getBranchVertex( vlast, bg.vertexRef() );
+		assertNotNull( "Last linked vertex should link to a branch vertex.", bvlast );
+		assertEquals( "Last branch vertex should link to last linked vertex in the branch.",
+				vlast, bg.getLinkedVertex( bvlast, graph.vertexRef() ) );
+
+		final BranchTestEdge be = bg.edges().iterator().next();
+		final ListenableTestEdge e1 = elist.get( 1 );
+		assertEquals( "Branch edge should link to first linked edge (second before removal) in the branch.",
+				e1, bg.getLinkedEdge( be, graph.edgeRef() ) );
+
+		final BranchTestEdge beref = bg.edgeRef();
+		for ( int i = 2; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex vi = vlist.get( i, ref1 );
+			assertNull( "Middle vertex should not link to a branch vertex.", bg.getBranchVertex( vi, bg.vertexRef() ) );
+			final BranchTestEdge bei = bg.getBranchEdge( vi, beref );
+			assertNotNull( "Middle vertex should link to a branch edge.", bei );
+			assertEquals( "Middle vertex shoud link to the branch edge.", be, bei );
+		}
+
+		for ( int i = 1; i < elist.size(); i++ )
+			assertEquals( "Linked edge should link to the branch edge.", be, bg.getBranchEdge( elist.get( i ), beref ) );
+
+		graph.releaseRef( ref1 );
+		graph.releaseRef( ref2 );
+		graph.releaseRef( eref );
+	}
+
+	@Test
+	public void testRemoveMiddleVertex()
+	{
+		final RefList< ListenableTestVertex > vlist = RefCollections.createRefList( graph.vertices() );
+		for ( int i = 0; i < 6; i++ )
+			vlist.add( graph.addVertex().init( i, i ) );
+		final RefList< ListenableTestEdge > elist = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex ref1 = graph.vertexRef();
+		final ListenableTestVertex ref2 = graph.vertexRef();
+		final ListenableTestEdge eref = graph.edgeRef();
+		for ( int i = 0; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex source = vlist.get( i, ref1 );
+			final ListenableTestVertex target = vlist.get( i + 1, ref2 );
+			final ListenableTestEdge edge = graph.addEdge( source, target, eref ).init();
+			elist.add( edge );
+		}
+
+		// Remove middle vertex.
+		final ListenableTestVertex toRemove = vlist.get( vlist.size() / 2 );
+		graph.remove( toRemove );
+		bg.graphRebuilt();
+
+		final ListenableTestVertex newTarget = vlist.get( vlist.size() / 2 - 1 );
+		final ListenableTestVertex newSource = vlist.get( vlist.size() / 2 + 1 );
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 4 vertices.", 4, vSize );
+
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 2 edges.", 2, eSize );
+
+		// First branch.
+		final ListenableTestVertex v0 = vlist.get( 0 );
+		final BranchTestVertex bv0 = bg.getBranchVertex( v0, bg.vertexRef() );
+		assertNotNull( "First linked vertex should link to a branch vertex.", bv0 );
+		assertEquals( "First branch vertex should link to first linked vertex in the branch.",
+				v0, bg.getLinkedVertex( bv0, graph.vertexRef() ) );
+
+		final BranchTestVertex bvNewTarget = bg.getBranchVertex( newTarget, bg.vertexRef() );
+		assertNotNull( "Last linked vertex in the new branch should link to a branch vertex.", bvNewTarget );
+		assertEquals( "Last branch vertex should link to last linked vertex in the first branch.",
+				newTarget, bg.getLinkedVertex( bvNewTarget, graph.vertexRef() ) );
+
+		final BranchTestEdge be1 = bv0.outgoingEdges().get( 0 );
+		final ListenableTestEdge e0 = elist.get( 0 );
+		assertEquals( "Branch edge should link to first linked edge in the branch.",
+				e0, bg.getLinkedEdge( be1, graph.edgeRef() ) );
+
+		final BranchTestEdge beref = bg.edgeRef();
+		for ( int i = 2; i < vlist.size() / 2 - 1; i++ )
+		{
+			final ListenableTestVertex vi = vlist.get( i, ref1 );
+			assertNull( "Middle vertex should not link to a branch vertex.", bg.getBranchVertex( vi, bg.vertexRef() ) );
+			final BranchTestEdge bei = bg.getBranchEdge( vi, beref );
+			assertNotNull( "Middle vertex should link to a branch edge.", bei );
+			assertEquals( "Middle vertex shoud link to the branch edge.", be1, bei );
+		}
+
+		for ( int i = 1; i < elist.size() / 2; i++ )
+			assertEquals( "Linked edge should link to the branch edge.",
+					be1, bg.getBranchEdge( elist.get( i ), beref ) );
+
+		// Second branch
+		final BranchTestVertex bvNewSource = bg.getBranchVertex( newSource, bg.vertexRef() );
+		assertNotNull( "First linked vertex in the new branch should link to a branch vertex.", bvNewSource );
+		assertEquals( "First branch vertex should link to first linked vertex in the second branch.",
+				newSource, bg.getLinkedVertex( bvNewSource, graph.vertexRef() ) );
+
+		final ListenableTestVertex vlast = vlist.get( vlist.size() - 1 );
+		final BranchTestVertex bvlast = bg.getBranchVertex( vlast, bg.vertexRef() );
+		assertNotNull( "Last linked vertex should link to a branch vertex.", bvlast );
+		assertEquals( "Last branch vertex should link to last linked vertex in the branch.",
+				vlast, bg.getLinkedVertex( bvlast, graph.vertexRef() ) );
+
+		final BranchTestEdge be2 = bvNewSource.outgoingEdges().get( 0 );
+		final ListenableTestEdge ens = newSource.outgoingEdges().get( 0 );
+		assertEquals( "Branch edge should link to first linked edge in the second branch.",
+				ens, bg.getLinkedEdge( be2, graph.edgeRef() ) );
+
+		for ( int i = vlist.size() / 2 + 2; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex vi = vlist.get( i, ref1 );
+			assertNull( "Middle vertex should not link to a branch vertex.",
+					bg.getBranchVertex( vi, bg.vertexRef() ) );
+			final BranchTestEdge bei = bg.getBranchEdge( vi, beref );
+			assertNotNull( "Middle vertex should link to a branch edge.", bei );
+			assertEquals( "Middle vertex shoud link to the branch edge.", be2, bei );
+		}
+
+		for ( int i = elist.size() / 2 + 2; i < elist.size(); i++ )
+			assertEquals( "Linked edge should link to the branch edge.",
+					be2, bg.getBranchEdge( elist.get( i ), beref ) );
+
+		graph.releaseRef( ref1 );
+		graph.releaseRef( ref2 );
+		graph.releaseRef( eref );
+	}
+
+	@Test
+	public void testRemoveLastVertex()
+	{
+		final RefList< ListenableTestVertex > vlist = RefCollections.createRefList( graph.vertices() );
+		for ( int i = 0; i < 6; i++ )
+			vlist.add( graph.addVertex().init( i, i ) );
+		final RefList< ListenableTestEdge > elist = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex ref1 = graph.vertexRef();
+		final ListenableTestVertex ref2 = graph.vertexRef();
+		final ListenableTestEdge eref = graph.edgeRef();
+		for ( int i = 0; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex source = vlist.get( i, ref1 );
+			final ListenableTestVertex target = vlist.get( i + 1, ref2 );
+			final ListenableTestEdge edge = graph.addEdge( source, target, eref ).init();
+			elist.add( edge );
+		}
+
+		// Remove last vertex.
+		graph.remove( vlist.get( vlist.size() - 1 ) );
+		bg.graphRebuilt();
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 2 vertices.", 2, vSize );
+
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 1 edge.", 1, eSize );
+
+		final ListenableTestVertex v0 = vlist.get( 0 );
+		final BranchTestVertex bv0 = bg.getBranchVertex( v0, bg.vertexRef() );
+		assertNotNull( "First linked vertex should link to a branch vertex.", bv0 );
+		assertEquals( "First branch vertex should link to first linked vertex in the branch.",
+				v0, bg.getLinkedVertex( bv0, graph.vertexRef() ) );
+
+		final ListenableTestVertex vforetolast = vlist.get( vlist.size() - 2 );
+		final BranchTestVertex bvlast = bg.getBranchVertex( vforetolast, bg.vertexRef() );
+		assertNotNull( "Last linked vertex should link to a branch vertex.", bvlast );
+		assertEquals( "Last branch vertex should link to last linked vertex in the branch.",
+				vforetolast, bg.getLinkedVertex( bvlast, graph.vertexRef() ) );
+
+		final BranchTestEdge be = bg.edges().iterator().next();
+		final ListenableTestEdge e0 = elist.get( 0 );
+		assertEquals( "Branch edge should link to first linked edge in the branch.",
+				e0, bg.getLinkedEdge( be, graph.edgeRef() ) );
+
+		final BranchTestEdge beref = bg.edgeRef();
+		for ( int i = 1; i < vlist.size() - 2; i++ )
+		{
+			final ListenableTestVertex vi = vlist.get( i, ref1 );
+			assertNull( "Middle vertex should not link to a branch vertex.", bg.getBranchVertex( vi, bg.vertexRef() ) );
+			final BranchTestEdge bei = bg.getBranchEdge( vi, beref );
+			assertNotNull( "Middle vertex should link to a branch edge.", bei );
+			assertEquals( "Middle vertex shoud link to the branch edge.", be, bei );
+		}
+
+		for ( int i = 0; i < elist.size() - 1; i++ )
+			assertEquals( "Linked edge should link to the branch edge.", be, bg.getBranchEdge( elist.get( i ), beref ) );
+
+		graph.releaseRef( ref1 );
+		graph.releaseRef( ref2 );
+		graph.releaseRef( eref );
+	}
+
+	@Test
+	public void testBranchingLambda()
+	{
+		// Make a long branch.
+		final RefList< ListenableTestVertex > vlist = RefCollections.createRefList( graph.vertices() );
+		for ( int i = 0; i < 7; i++ )
+			vlist.add( graph.addVertex().init( i, i ) );
+		final RefList< ListenableTestEdge > elist = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex ref1 = graph.vertexRef();
+		final ListenableTestVertex ref2 = graph.vertexRef();
+		final ListenableTestEdge eref = graph.edgeRef();
+		for ( int i = 0; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex source = vlist.get( i, ref1 );
+			final ListenableTestVertex target = vlist.get( i + 1, ref2 );
+			final ListenableTestEdge edge = graph.addEdge( source, target, eref ).init();
+			elist.add( edge );
+		}
+
+		// Branch from its middle vertex in lambda shape (split event).
+		final ListenableTestVertex middle = vlist.get( vlist.size() / 2 );
+		ListenableTestVertex source = middle;
+		for ( int i = 0; i < vlist.size() / 2; i++ )
+		{
+			final ListenableTestVertex target = graph.addVertex().init( vlist.size() + i, middle.getTimepoint() + i + 1 );
+			vlist.add( target );
+			final ListenableTestEdge e = graph.addEdge( source, target, eref ).init();
+			elist.add( e );
+			source = target;
+		}
+
+		bg.graphRebuilt();
+
+		// Basic test on N vertices and N edges.
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 4 vertices.", 4, vSize );
+
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 3 edges.", 3, eSize );
+
+		// Test that we branched correctly.
+		final BranchTestVertex middleBV = bg.getBranchVertex( middle, bg.vertexRef() );
+		assertNotNull( "Middle linked vertex should link to a branch vertex.", middleBV );
+		assertEquals( "Middle branch vertex should link to middle linked vertex in the branch.",
+				middle, bg.getLinkedVertex( middleBV, graph.vertexRef() ) );
+
+		final ListenableTestVertex first = vlist.get( 0 );
+		final BranchTestVertex firstBV = bg.getBranchVertex( first, bg.vertexRef() );
+		final ListenableTestEdge efirst = first.outgoingEdges().get( 0 );
+		final BranchTestEdge efirstBE = bg.getBranchEdge( efirst, bg.edgeRef() );
+		assertEquals( "Outgoing edge of a BV should link to the first edge of the linked branch.",
+				firstBV.outgoingEdges().get( 0 ), efirstBE );
+
+		// First branch.
+		for ( int i = 1; i < 3; i++ )
+		{
+			final ListenableTestVertex v = vlist.get( i );
+			assertNull( "Vertex in the middle of a branch should not link to a branch vertex.", bg.getBranchVertex( v, bg.vertexRef() ) );
+			assertEquals( "Vertex  in the middle of a branch should link to a branch edge.", efirstBE, bg.getBranchEdge( v, bg.edgeRef() ) );
+		}
+	}
+
+	@Test
+	public void testBranchingY()
+	{
+		// Make a long branch.
+		final RefList< ListenableTestVertex > vlist = RefCollections.createRefList( graph.vertices() );
+		for ( int i = 0; i < 7; i++ )
+			vlist.add( graph.addVertex().init( i, i ) );
+		final RefList< ListenableTestEdge > elist = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex ref1 = graph.vertexRef();
+		final ListenableTestVertex ref2 = graph.vertexRef();
+		final ListenableTestEdge eref = graph.edgeRef();
+		for ( int i = 0; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex source = vlist.get( i, ref1 );
+			final ListenableTestVertex target = vlist.get( i + 1, ref2 );
+			final ListenableTestEdge edge = graph.addEdge( source, target, eref ).init();
+			elist.add( edge );
+		}
+		final ListenableTestVertex middle = vlist.get( vlist.size() / 2 );
+
+		// Branch from its middle vertex in Y shape (merge event).
+		final ListenableTestVertex source = graph.addVertex().init( vlist.size(), 0 );
+		ListenableTestVertex target = null;
+		vlist.add( source );
+		for ( int i = 1; i < 4; i++ )
+		{
+			target = graph.addVertex().init( vlist.size(), i );
+			vlist.add( target );
+			final ListenableTestEdge e = graph.addEdge( source, target, eref ).init();
+			elist.add( e );
+			source.refTo( target );
+		}
+		graph.addEdge( target, middle, eref ).init();
+		bg.graphRebuilt();
+
+		// Basic test on N vertices and N edges.
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 4 vertices.", 4, vSize );
+
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 3 edges.", 3, eSize );
+
+		// First branch.
+		final ListenableTestVertex first = vlist.get( 0 );
+		final BranchTestVertex firstBV = bg.getBranchVertex( first, bg.vertexRef() );
+		final ListenableTestEdge efirst = first.outgoingEdges().get( 0 );
+		final BranchTestEdge efirstBE = bg.getBranchEdge( efirst, bg.edgeRef() );
+		assertEquals( "Outgoing edge of a BV should link to the first edge of the linked branch.",
+				firstBV.outgoingEdges().get( 0 ), efirstBE );
+
+		for ( int i = 1; i < 3; i++ )
+		{
+			final ListenableTestVertex v = vlist.get( i );
+			assertNull( "Vertex in the middle of a branch should not link to a branch vertex.", bg.getBranchVertex( v, bg.vertexRef() ) );
+			assertEquals( "Vertex  in the middle of a branch should link to a branch edge.", efirstBE, bg.getBranchEdge( v, bg.edgeRef() ) );
+		}
+
+		// Other half, test that we branched correctly.
+		final BranchTestVertex middleBV = bg.getBranchVertex( middle, bg.vertexRef() );
+		assertNotNull( "Middle linked vertex should link to a branch vertex.", middleBV );
+		assertEquals( "Middle branch vertex should link to middle linked vertex in the branch.",
+				middle, bg.getLinkedVertex( middleBV, graph.vertexRef() ) );
+
+		final ListenableTestEdge emiddle = middle.outgoingEdges().get( 0 );
+		final BranchTestEdge emiddleBE = bg.getBranchEdge( emiddle, bg.edgeRef() );
+		assertEquals( "Outgoing edge of a BV should link to the first edge of the linked branch.",
+				middleBV.outgoingEdges().get( 0 ), emiddleBE );
+
+		for ( int i = 4; i < 6; i++ )
+		{
+			final ListenableTestVertex v = vlist.get( i );
+			assertNull( "Vertex in the middle of a branch should not link to a branch vertex.", bg.getBranchVertex( v, bg.vertexRef() ) );
+			assertEquals( "Vertex  in the middle of a branch should link to a branch edge.", emiddleBE, bg.getBranchEdge( v, bg.edgeRef() ) );
+		}
+
+		final ListenableTestVertex last = vlist.get( 6 );
+		final BranchTestVertex lastBV = bg.getBranchVertex( last, bg.vertexRef() );
+		assertNotNull( "Last linked vertex should link to a branch vertex.", lastBV );
+		assertEquals( "Last branch vertex should link to last linked vertex in the branch.",
+				last, bg.getLinkedVertex( lastBV, graph.vertexRef() ) );
+
+		// Half Y branch.
+		final ListenableTestVertex other = vlist.get( 7 );
+		final BranchTestVertex otherBV = bg.getBranchVertex( other, bg.vertexRef() );
+		assertNotNull( "First linked vertex in the new branch should link to a branch vertex.", otherBV );
+		assertEquals( "Branch vertex should link to new root in the branch.",
+				other, bg.getLinkedVertex( otherBV, graph.vertexRef() ) );
+
+		final ListenableTestEdge eother = other.outgoingEdges().get( 0 );
+		final BranchTestEdge eotherBE = bg.getBranchEdge( eother, bg.edgeRef() );
+
+		assertEquals( "Outgoing edge of a BV should link to the first edge of the linked branch.",
+				otherBV.outgoingEdges().get( 0 ), eotherBE );
+
+		for ( int i = 8; i <= 10; i++ )
+		{
+			final ListenableTestVertex v = vlist.get( i );
+			assertNull( "Vertex in the middle of a branch should not link to a branch vertex.", bg.getBranchVertex( v, bg.vertexRef() ) );
+			assertEquals( "Vertex  in the middle of a branch should link to a branch edge.", eotherBE, bg.getBranchEdge( v, bg.edgeRef() ) );
+		}
+	}
+
+	@Test
+	public void testDiamond()
+	{
+		// Make a branch.
+		final RefList< ListenableTestVertex > vlist = RefCollections.createRefList( graph.vertices() );
+		for ( int i = 0; i < 4; i++ )
+			vlist.add( graph.addVertex().init( i, i ) );
+		final RefList< ListenableTestEdge > elist = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex ref1 = graph.vertexRef();
+		final ListenableTestVertex ref2 = graph.vertexRef();
+		final ListenableTestEdge eref = graph.edgeRef();
+		for ( int i = 0; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex source = vlist.get( i, ref1 );
+			final ListenableTestVertex target = vlist.get( i + 1, ref2 );
+			final ListenableTestEdge edge = graph.addEdge( source, target, eref ).init();
+			elist.add( edge );
+		}
+		final ListenableTestVertex first = vlist.get( 0 );
+		final ListenableTestVertex last = vlist.get( vlist.size() - 1 );
+
+		// Mess it by running a parallel branch to this one.
+		final ListenableTestVertex v1 = graph.addVertex().init( vlist.size(), 0 );
+		vlist.add( v1 );
+		final ListenableTestEdge e1 = graph.addEdge( first, v1 ).init();
+		elist.add( e1 );
+		final ListenableTestVertex v2 = graph.addVertex().init( vlist.size(), 1 );
+		vlist.add( v2 );
+		final ListenableTestEdge e2 = graph.addEdge( v1, v2 ).init();
+		elist.add( e2 );
+		final ListenableTestEdge e3 = graph.addEdge( v2, last ).init();
+		elist.add( e3 );
+
+		bg.graphRebuilt();
+
+		// Basic test on N vertices and N edges.
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 2 vertices.", 2, vSize );
+
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 2 edges.", 2, eSize );
+
+		for ( final BranchTestEdge be : edges )
+		{
+			ListenableTestEdge e0 = bg.getLinkedEdge( be, graph.edgeRef() );
+			do
+			{
+				assertEquals( "Linked edge in the first branch should link to the right branch edge.",
+						be, bg.getBranchEdge( e0, bg.edgeRef() ) );
+			}
+			while ( ( !e0.getTarget().outgoingEdges().isEmpty() )
+					&& ( e0 = e0.getTarget().outgoingEdges().get( 0 ) ) != null );
+		}
+	}
+
+	/*
+	 * TODO
+	 * 
+	 * This test fails, because the graphRebuilt() method cannot detect rings.
+	 * It rebuilds the branch graph starting from the roots of the core graph.
+	 * And a ring does not have any root...
+	 * 
+	 * A way to fix this would be to avoid starting from the roots. Start from a
+	 * random vertex and iterate up until we reach a root, or the starting
+	 * point. But this would be costly because we would have to keep track of
+	 * all the vertices we visited this way and iterate through them.
+	 * 
+	 */
+//	@Test
+	public void testRing()
+	{
+		final RefList< ListenableTestVertex > vlist = RefCollections.createRefList( graph.vertices() );
+		for ( int i = 0; i < 4; i++ )
+			vlist.add( graph.addVertex().init( i, i ) );
+		final RefList< ListenableTestEdge > elist = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex ref1 = graph.vertexRef();
+		final ListenableTestVertex ref2 = graph.vertexRef();
+		final ListenableTestEdge eref = graph.edgeRef();
+		for ( int i = 0; i < vlist.size() - 1; i++ )
+		{
+			final ListenableTestVertex source = vlist.get( i, ref1 );
+			final ListenableTestVertex target = vlist.get( i + 1, ref2 );
+			final ListenableTestEdge edge = graph.addEdge( source, target, eref ).init();
+			elist.add( edge );
+		}
+		final ListenableTestVertex first = vlist.get( 0 );
+		final ListenableTestVertex last = vlist.get( vlist.size() - 1 );
+
+		// Create a ring.
+		graph.addEdge( last, first ).init();
+		bg.graphRebuilt();
+
+		// Basic test on N vertices and N edges.
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 1 edge.", 1, eSize );
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 1 vertex.", 1, vSize );
+
+		final BranchTestVertex bv0 = bg.vertices().iterator().next();
+		final ListenableTestVertex v0 = bg.getLinkedVertex( bv0, graph.vertexRef() );
+		final BranchTestEdge be0 = bg.edges().iterator().next();
+
+		assertNotNull( "The branch vertex linked to this vertex should not be null.", bg.getBranchVertex( v0, bg.vertexRef() ) );
+		assertNull( "The branch edge linked to this vertex should be null.", bg.getBranchEdge( v0, bg.edgeRef() ) );
+
+		vlist.remove( v0 );
+		for ( final ListenableTestVertex lv : vlist )
+		{
+			assertNull( "The branch vertex linked to this vertex should be null.", bg.getBranchVertex( lv, bg.vertexRef() ) );
+			assertEquals( "The branch edge linked to this vertex should be the one branch edge.",
+					be0, bg.getBranchEdge( lv, bg.edgeRef() ) );
+		}
+		for ( final ListenableTestEdge le : elist )
+		{
+			assertEquals( "The branch edge linked to any edge in the loop should be the one branch edge.",
+					be0, bg.getBranchEdge( le, bg.edgeRef() ) );
+		}
+
+		final ListenableTestEdge le0 = bg.getLinkedEdge( be0, graph.edgeRef() );
+		assertEquals( "The one branch vertex should link to an edge that has the one branch vertex linked vertex as a source.",
+				v0, le0.getSource() );
+	}
+
+	@Test
+	public void testTwoSplittingBranches()
+	{
+		// The root.
+		final ListenableTestVertex v0 = graph.addVertex().init( 0, 0 );
+
+		// Make the first branch.
+		final RefList< ListenableTestVertex > vlistA = RefCollections.createRefList( graph.vertices() );
+		final RefList< ListenableTestEdge > elistA = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex source = graph.vertexRef();
+		source.refTo( v0 );
+		for ( int i = 0; i < 7; i++ )
+		{
+			final ListenableTestVertex target = graph.addVertex().init( i + 10, i + 1 );
+			vlistA.add( target );
+			final ListenableTestEdge e = graph.addEdge( source, target ).init();
+			elistA.add( e );
+			source.refTo( target );
+		}
+
+		// Make the second branch.
+		final RefList< ListenableTestVertex > vlistB = RefCollections.createRefList( graph.vertices() );
+		final RefList< ListenableTestEdge > elistB = RefCollections.createRefList( graph.edges() );
+		source.refTo( v0 );
+		for ( int i = 0; i < 7; i++ )
+		{
+			final ListenableTestVertex target = graph.addVertex().init( i + 100, i + 1 );
+			vlistB.add( target );
+			final ListenableTestEdge e = graph.addEdge( source, target ).init();
+			elistB.add( e );
+			source.refTo( target );
+		}
+
+		// Remove the root.
+		graph.remove( v0 );
+		bg.graphRebuilt();
+
+		assertNull( "There should be not branch vertex linked to a removed vertex.",
+				bg.getBranchVertex( v0, bg.vertexRef() ) );
+		assertNull( "There should be not branch edge linked to a removed vertex.",
+				bg.getBranchEdge( v0, bg.edgeRef() ) );
+		assertNull( "There should be not branch edge linked to a removed edge.",
+				bg.getBranchEdge( elistA.get( 0 ), bg.edgeRef() ) );
+		assertNull( "There should be not branch edge linked to a removed edge.",
+				bg.getBranchEdge( elistB.get( 0 ), bg.edgeRef() ) );
+
+		// Basic test on N vertices and N edges.
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 2 edges.", 2, eSize );
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 4 vertices.", 4, vSize );
+		graph.releaseRef( source );
+	}
+
+	@Test
+	public void testTwoMergingBranches()
+	{
+		// The root.
+		final ListenableTestVertex v0 = graph.addVertex().init( 0, 0 );
+
+		// Make the first branch.
+		final RefList< ListenableTestVertex > vlistA = RefCollections.createRefList( graph.vertices() );
+		final RefList< ListenableTestEdge > elistA = RefCollections.createRefList( graph.edges() );
+		ListenableTestVertex target = null;
+		for ( int i = 0; i < 7; i++ )
+		{
+			final ListenableTestVertex source = graph.addVertex().init( i + 10, i + 1 );
+			vlistA.add( source );
+			if ( target == null )
+			{
+				target = graph.vertexRef();
+				target.refTo( source );
+			}
+			else
+			{
+				final ListenableTestEdge e = graph.addEdge( source, target ).init();
+				elistA.add( e );
+				target.refTo( source );
+			}
+		}
+		elistA.add( graph.addEdge( target, v0 ).init() );
+
+		// Make the second branch.
+		final RefList< ListenableTestVertex > vlistB = RefCollections.createRefList( graph.vertices() );
+		final RefList< ListenableTestEdge > elistB = RefCollections.createRefList( graph.edges() );
+		target = null;
+		for ( int i = 0; i < 7; i++ )
+		{
+			final ListenableTestVertex source = graph.addVertex().init( i + 100, i + 1 );
+			vlistB.add( source );
+			if ( target == null )
+			{
+				target = graph.vertexRef();
+				target.refTo( source );
+			}
+			else
+			{
+				final ListenableTestEdge e = graph.addEdge( source, target ).init();
+				elistB.add( e );
+				target.refTo( source );
+			}
+		}
+		elistB.add( graph.addEdge( target, v0 ).init() );
+
+		// Remove the root.
+		graph.remove( v0 );
+		bg.graphRebuilt();
+
+		assertNull( "There should be not branch vertex linked to a removed vertex.",
+				bg.getBranchVertex( v0, bg.vertexRef() ) );
+		assertNull( "There should be not branch edge linked to a removed vertex.",
+				bg.getBranchEdge( v0, bg.edgeRef() ) );
+		assertNull( "There should be not branch edge linked to a removed edge.",
+				bg.getBranchEdge( elistA.get( elistA.size() - 1 ), bg.edgeRef() ) );
+		assertNull( "There should be not branch edge linked to a removed edge.",
+				bg.getBranchEdge( elistB.get( elistB.size() - 1 ), bg.edgeRef() ) );
+
+		// Basic test on N vertices and N edges.
+		final RefCollection< BranchTestEdge > edges = bg.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 2 edges.", 2, eSize );
+
+		final RefCollection< BranchTestVertex > vertices = bg.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 4 vertices.", 4, vSize );
+		graph.releaseRef( target );
+	}
+
+	@Test
+	public void testGraphRebuilt()
+	{
+		// The root.
+		final ListenableTestVertex v0 = graph.addVertex().init( 0, 0 );
+
+		// Make the first branch.
+		final RefList< ListenableTestVertex > vlistA = RefCollections.createRefList( graph.vertices() );
+		final RefList< ListenableTestEdge > elistA = RefCollections.createRefList( graph.edges() );
+		final ListenableTestVertex source = graph.vertexRef();
+		source.refTo( v0 );
+		for ( int i = 0; i < 7; i++ )
+		{
+			final ListenableTestVertex target = graph.addVertex().init( i + 10, i + 1 );
+			vlistA.add( target );
+			final ListenableTestEdge e = graph.addEdge( source, target ).init();
+			elistA.add( e );
+			source.refTo( target );
+		}
+
+		// Make the second branch.
+		final RefList< ListenableTestVertex > vlistB = RefCollections.createRefList( graph.vertices() );
+		final RefList< ListenableTestEdge > elistB = RefCollections.createRefList( graph.edges() );
+		source.refTo( v0 );
+		for ( int i = 0; i < 7; i++ )
+		{
+			final ListenableTestVertex target = graph.addVertex().init( i + 100, i + 1 );
+			vlistB.add( target );
+			final ListenableTestEdge e = graph.addEdge( source, target ).init();
+			elistB.add( e );
+			source.refTo( target );
+		}
+
+		// Build a new branch graph from this one.
+		final BranchGraph< BranchTestVertex, BranchTestEdge, ListenableTestVertex, ListenableTestEdge > bg2 =
+				new BranchTestGraph( graph, new BranchTestEdgePool( 50, new BranchTestVertexPool( 50 ) ) );
+
+		// Basic test on N vertices and N edges.
+		final RefCollection< BranchTestEdge > edges = bg2.edges();
+		final int eSize = edges.size();
+		assertEquals( "Expected the branch graph to have 2 edges.", 2, eSize );
+
+		final RefCollection< BranchTestVertex > vertices = bg2.vertices();
+		final int vSize = vertices.size();
+		assertEquals( "Expected the branch graph to have 3 vertices.", 3, vSize );
+
+		// Remove the root.
+		graph.remove( v0 );
+
+		assertNull( "There should be not branch vertex linked to a removed vertex.",
+				bg.getBranchVertex( v0, bg.vertexRef() ) );
+		assertNull( "There should be not branch edge linked to a removed vertex.",
+				bg.getBranchEdge( v0, bg.edgeRef() ) );
+		assertNull( "There should be not branch edge linked to a removed edge.",
+				bg.getBranchEdge( elistA.get( 0 ), bg.edgeRef() ) );
+		assertNull( "There should be not branch edge linked to a removed edge.",
+				bg.getBranchEdge( elistB.get( 0 ), bg.edgeRef() ) );
+
+		// Basic test on N vertices and N edges.
+		assertEquals( "Expected the branch graph to have 2 edges.", 2, bg2.edges().size() );
+		assertEquals( "Expected the branch graph to have 4 vertices.", 4, bg2.vertices().size() );
+	}
+
+}

--- a/src/test/java/org/mastodon/graph/branch/BranchTestGraph.java
+++ b/src/test/java/org/mastodon/graph/branch/BranchTestGraph.java
@@ -46,6 +46,8 @@ public class BranchTestGraph extends BranchGraphImp<
 	public BranchTestGraph( final ListenableGraph< ListenableTestVertex, ListenableTestEdge > graph, final BranchTestEdgePool branchEdgePool )
 	{
 		super( graph, branchEdgePool );
+		// Listen to incremental changes.
+		graph.addGraphListener( this );
 	}
 
 	@Override

--- a/src/test/java/org/mastodon/graph/branch/BranchTestGraphIncremental.java
+++ b/src/test/java/org/mastodon/graph/branch/BranchTestGraphIncremental.java
@@ -33,7 +33,12 @@ import org.mastodon.graph.ListenableTestEdge;
 import org.mastodon.graph.ListenableTestVertex;
 import org.mastodon.pool.ByteMappedElement;
 
-public class BranchTestGraph extends BranchGraphImp<
+/**
+ * Version of the BranchTestGraph that listens to incremental changes.
+ * 
+ * @author Jean-Yves Tinevez
+ */
+public class BranchTestGraphIncremental extends BranchGraphImpIncremental<
 	ListenableTestVertex,
 	ListenableTestEdge,
 	BranchTestVertex,
@@ -43,9 +48,11 @@ public class BranchTestGraph extends BranchGraphImp<
 	ByteMappedElement >
 {
 
-	public BranchTestGraph( final ListenableGraph< ListenableTestVertex, ListenableTestEdge > graph, final BranchTestEdgePool branchEdgePool )
+	public BranchTestGraphIncremental( final ListenableGraph< ListenableTestVertex, ListenableTestEdge > graph, final BranchTestEdgePool branchEdgePool )
 	{
 		super( graph, branchEdgePool );
+		// Listen to incremental changes.
+		graph.addGraphListener( this );
 	}
 
 	@Override


### PR DESCRIPTION
## Branch-graph implementations.

Despite my best efforts I could not implement a robust branch-graph that is listening to incremental changes. I went as far as I could but I could not make it perfect, and got quite depressed about it at some point. In brief, the incremental-changes version works in test cases, and in most cases in the Mamut app, but fails when the user does a big batch of changes (such as deleting half of the whole core graph). When I investigated it turns out that some of the map becomes invalid, but if I try to fix them other bugs appear. 

My crude solution was to rely on an implementation that does not listen to incremental changes, with another class. There are now two abstract branch-graph implementations. 


### `BranchGraphImp`

https://github.com/mastodon-sc/mastodon-graph/blob/fix-branch-graph/src/main/java/org/mastodon/graph/branch/BranchGraphImp.java

The `BranchGraphImp` class does not implement incremental changes. The branch-graph is only rebuilt upon calls of the `graphRebuilt()` method. The methods `edgeAdded(Edge)`, `edgeRemoved(Edge)`, `vertexAdded(Vertex)` and `vertexRemoved(Vertex)` do not do anything.

As a side effect, this implementation does not support 'rings'. If a connected component in the core-graph looks like this:

```
	 A -> B -> C -> D -> A
```

(edge direction is important), it won't be discovered in the branch-graph,which requires 'roots' to be built. (Roots are
vertices with no incoming edges.) 'Diamonds' connected components:

```
	A -> B -> D
and
	A -> C -> D
```

are supported.



### `BranchGraphImpIncremental`

https://github.com/mastodon-sc/mastodon-graph/blob/fix-branch-graph/src/main/java/org/mastodon/graph/branch/BranchGraphImpIncremental.java 

The `BranchGraphImpIncremental` class supports incremental changes. But there are still bugs when making batch changes in the core-graph. They are probably linked to not locking the core-graph and not cleaning the maps. This class should not be used without uttermost cautious, and could do with a revamp.

There are JUnit tests for both implementations.

There a lot of common codes between the two implementations but we cannot subclass one with the other because we need to specifically call some methods in the superclass.

This is a crude way of casting away a piece of code I do not trust.